### PR TITLE
fixes: 修复 height=width/2 时，生成 sin line 失败

### DIFF
--- a/engineImageChar.go
+++ b/engineImageChar.go
@@ -128,6 +128,8 @@ func (captcha *CaptchaImageChar) drawSineLine() *CaptchaImageChar {
 	var t float64
 	if captcha.ImageHeight > captcha.ImageWidth/2 {
 		t = random(int64(captcha.ImageWidth/2), int64(captcha.ImageHeight))
+	} else if captcha.ImageHeight == captcha.ImageWidth/2 {
+		t = float64(captcha.ImageHeight)
 	} else {
 		t = random(int64(captcha.ImageHeight), int64(captcha.ImageWidth/2))
 	}


### PR DESCRIPTION
stacktrace:

```
2018/06/08 14:26:35 http: panic serving 127.0.0.1:56989: invalid range 30 >= 30
goroutine 50 [running]:
net/http.(*conn).serve.func1(0xc420390000)
        /usr/local/Cellar/go/1.10.3/libexec/src/net/http/server.go:1726 +0xd0
panic(0x14cfaa0, 0xc420462180)
        /usr/local/Cellar/go/1.10.3/libexec/src/runtime/panic.go:502 +0x229
captcha/vendor/github.com/mojocn/base64Captcha.random(0x1e, 0x1e, 0x4002606cd2b57d29)
        /Users/Vcs/captcha-server/src/captcha/vendor/github.com/mojocn/base64Captcha/randomMath.go:55 +0x2c6
captcha/vendor/github.com/mojocn/base64Captcha.(*CaptchaImageChar).drawSineLine(0xc42015a440, 0x0)
 ```