### PR TITLE
fix(redis): Fixed a get/set error not returning

### DIFF
--- a/_examples_redis/main.go
+++ b/_examples_redis/main.go
@@ -19,15 +19,16 @@ type customizeRdsStore struct {
 }
 
 // customizeRdsStore implementing Set method of  Store interface
-func (s *customizeRdsStore) Set(id string, value string) {
-	err := s.redisClient.Set(id, value, time.Minute*10).Err()
+func (s *customizeRdsStore) Set(id string, value string) (err error) {
+	err = s.redisClient.Set(id, value, time.Minute*10).Err()
 	if err != nil {
 		panic(err)
 	}
+	return
 }
 
 // customizeRdsStore implementing Get method of  Store interface
-func (s *customizeRdsStore) Get(id string, clear bool) (value string) {
+func (s *customizeRdsStore) Get(id string, clear bool) (value string, err error) {
 	val, err := s.redisClient.Get(id).Result()
 	if err != nil {
 		panic(err)
@@ -38,7 +39,7 @@ func (s *customizeRdsStore) Get(id string, clear bool) (value string) {
 			panic(err)
 		}
 	}
-	return val
+	return val, err
 }
 
 func init() {
@@ -49,9 +50,9 @@ func init() {
 		DB:       0,  // use default DB
 	})
 	// init redis store
-	customeStore := customizeRdsStore{client}
+	customerStore := customizeRdsStore{client}
 
-	base64Captcha.SetCustomStore(&customeStore)
+	base64Captcha.SetCustomStore(&customerStore)
 
 }
 

--- a/store/interface.go
+++ b/store/interface.go
@@ -9,9 +9,9 @@ package store
 // method after the certain amount of captchas has been stored.)
 type Store interface {
 	// Set sets the digits for the captcha id.
-	Set(id string, value string)
+	Set(id string, value string) error
 
 	// Get returns stored digits for the captcha id. Clear indicates
 	// whether the captcha must be deleted from the store.
-	Get(id string, clear bool) string
+	Get(id string, clear bool) (string, error)
 }

--- a/store/memory.go
+++ b/store/memory.go
@@ -53,7 +53,7 @@ func NewMemoryStore(collectNum int, expiration time.Duration) Store {
 	return s
 }
 
-func (s *memoryStore) Set(id string, value string) {
+func (s *memoryStore) Set(id string, value string) (err error) {
 	s.Lock()
 	s.digitsById[id] = value
 	s.idByTime.PushBack(idByTimeValue{time.Now(), id})
@@ -62,9 +62,10 @@ func (s *memoryStore) Set(id string, value string) {
 	if s.numStored > s.collectNum {
 		go s.collect()
 	}
+	return nil
 }
 
-func (s *memoryStore) Get(id string, clear bool) (value string) {
+func (s *memoryStore) Get(id string, clear bool) (value string, err error) {
 	if !clear {
 		// When we don't need to clear captcha, acquire read lock.
 		s.RLock()

--- a/store/redis.go
+++ b/store/redis.go
@@ -28,13 +28,12 @@ func NewRedisStore(client *redis.Client, prefix string, expiration time.Duration
 	return s
 }
 
-func (s *redisStore) Set(id string, value string) {
-	s.client.Set(s.prefix+id, value, s.expiration)
+func (s *redisStore) Set(id string, value string) (err error) {
+	return s.client.Set(s.prefix+id, value, s.expiration).Err()
 }
 
-func (s *redisStore) Get(id string, clear bool) (value string) {
+func (s *redisStore) Get(id string, clear bool) (value string, err error) {
 
-	var err error
 	if clear {
 		value, err = s.getAndClear(id)
 	} else {
@@ -42,7 +41,7 @@ func (s *redisStore) Get(id string, clear bool) (value string) {
 	}
 
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	return

--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -26,8 +26,10 @@ func TestRedisStore_Get(t *testing.T) {
 	value := fmt.Sprintf("%d", rand.Int63())
 	s := NewRedisStore(c, "test:", 5*time.Minute)
 	c.Set("test:"+id, value, 5*time.Minute)
-	assert.Equal(t, value, s.Get(id, false))
-	assert.Equal(t, value, c.Get("test:"+id).Val())
+	result, err := s.Get(id, false)
+	assert.Nil(t, err)
+	assert.Equal(t, value, result)
+	assert.Equal(t, value, c.Get("test:" + id).Val())
 }
 
 func TestRedisStore_GetAndClear(t *testing.T) {
@@ -39,8 +41,10 @@ func TestRedisStore_GetAndClear(t *testing.T) {
 	value := fmt.Sprintf("%d", rand.Int63())
 	s := NewRedisStore(c, "test:", 5*time.Minute)
 	c.Set("test:"+id, value, 5*time.Minute)
-	assert.Equal(t, value, s.Get(id, true))
-	assert.Equal(t, int64(0), c.Exists("test:"+id).Val())
+	result, err := s.Get(id, true)
+	assert.Nil(t, err)
+	assert.Equal(t, value, result)
+	assert.Equal(t, int64(0), c.Exists("test:" + id).Val())
 }
 
 func TestNewRedisStoreByClient(t *testing.T) {
@@ -62,7 +66,8 @@ func TestRedisStore_Set(t *testing.T) {
 	s := NewRedisStore(redis.NewClient(&redis.Options{
 		Addr: "127.0.0.1:6379",
 	}), "test:", 5*time.Minute)
-	s.Set(id, value)
+	err := s.Set(id, value)
+	assert.Nil(t, err)
 	verifyCode, err := c.Get("test:" + id).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, value, verifyCode)
@@ -74,7 +79,9 @@ func TestRedisStore_GetFailed(t *testing.T) {
 	s := NewRedisStore(redis.NewClient(&redis.Options{
 		Addr: "127.0.0.1:6379",
 	}), "test:", 5*time.Minute)
-	assert.Equal(t, "", s.Get(id, false))
+	value, err := s.Get(id, false)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", value)
 }
 
 func TestRedisStore_GetFailed2(t *testing.T) {
@@ -83,5 +90,7 @@ func TestRedisStore_GetFailed2(t *testing.T) {
 	s := NewRedisStore(redis.NewClient(&redis.Options{
 		Addr: "127.0.0.1:6379",
 	}), "test:", 5*time.Minute)
-	assert.Equal(t, "", s.Get(id, true))
+	value, err := s.Get(id, true)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", value)
 }


### PR DESCRIPTION
Since the previous "store.Store" interface did not return an error, the upper caller could not know that the storage error occurred. This problem will cause the upper caller to know the specific error message when a storage error occurs during the generation or verification of the verification code.