### PR TITLE
允许指定顺序的词组

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ func demoCodeCaptchaCreate() {
 	var configC = base64Captcha.ConfigCharacter{
 		Height:             60,
 		Width:              240,
-		//const CaptchaModeNumber:数字,CaptchaModeAlphabet:字母,CaptchaModeArithmetic:算术,CaptchaModeNumberAlphabet:数字字母混合.
+		//const CaptchaModeNumber:数字
+		//      CaptchaModeAlphabet:字母
+		//      CaptchaModeArithmetic:算术
+		//      CaptchaModeNumberAlphabet:数字字母混合.
+		//      CaptchaModeChinese: 中文字符串
+		//      CaptchaModeUseSequencedCharacters:  在指定词组中随机（内部保持词组有序)
 		Mode:               base64Captcha.CaptchaModeNumber,
 		ComplexOfNoiseText: base64Captcha.CaptchaComplexLower,
 		ComplexOfNoiseDot:  base64Captcha.CaptchaComplexLower,
@@ -66,8 +71,32 @@ func demoCodeCaptchaCreate() {
 		IsShowNoiseText:    false,
 		IsShowSlimeLine:    false,
 		IsShowSineLine:     false,
+		// 随机中文字符串来源，在CaptchaModeChinese时有效。
+		ChineseCharacterSource： "",
+		// 随机词组，在CaptchaModeUseSequencedCharacters时有效
+		SequencedCharacters: []string {"中文","英文","其他"},
 		CaptchaLen:         6,
 	}
+	//创建声音验证码
+	//GenerateCaptcha 第一个参数为空字符串,包会自动在服务器一个随机种子给你产生随机uiid.
+	idKeyA, capA := base64Captcha.GenerateCaptcha("", configA)
+	//以base64编码
+	base64stringA := base64Captcha.CaptchaWriteToBase64Encoding(capA)
+	//创建字符公式验证码.
+	//GenerateCaptcha 第一个参数为空字符串,包会自动在服务器一个随机种子给你产生随机uiid.
+	idKeyC, capC := base64Captcha.GenerateCaptcha("", configC)
+	//以base64编码
+	base64stringC := base64Captcha.CaptchaWriteToBase64Encoding(capC)
+	//创建数字验证码.
+	//GenerateCaptcha 第一个参数为空字符串,包会自动在服务器一个随机种子给你产生随机uiid.
+	idKeyD, capD := base64Captcha.GenerateCaptcha("", configD)
+	//以base64编码
+	base64stringD := base64Captcha.CaptchaWriteToBase64Encoding(capD)
+    
+	fmt.Println(idKeyA, base64stringA, "\n")
+	fmt.Println(idKeyC, base64stringC, "\n")
+	fmt.Println(idKeyD, base64stringD, "\n")
+}
 	//create a audio captcha.
 	//GenerateCaptcha first parameter is empty string,so the package will generate a random uuid for you.
 	idKeyA, capA := base64Captcha.GenerateCaptcha("", configA)
@@ -283,21 +312,29 @@ func main() {
     ```
 - ConfigCharacter captcha config for captcha-engine-characters.
     ```
+    //ConfigCharacter captcha config for captcha-engine-characters.
     type ConfigCharacter struct {
-        // Height png height in pixel.
+        //  Height png height in pixel.
         // 图像验证码的高度像素.
         Height int
         // Width Captcha png width in pixel.
         // 图像验证码的宽度像素
         Width int
-        //Mode : base64captcha.CaptchaModeNumber=0, base64captcha.CaptchaModeAlphabet=1, base64captcha.CaptchaModeArithmetic=2, base64captcha.CaptchaModeNumberAlphabet=3.
+        //Mode :
+        //    base64captcha.CaptchaModeNumber=0,
+        //    base64captcha.CaptchaModeAlphabet=1,
+        //    base64captcha.CaptchaModeArithmetic=2,
+        //    base64captcha.CaptchaModeNumberAlphabet=3,
+        //    base64captcha.CaptchaModeChinese=4,
+        //    base64captcha.CaptchaModeUseSequencedCharacters=5
         Mode int
+        //IsUseSimpleFont is use simply font(...base64Captcha/fonts/RitaSmith.ttf).
+        IsUseSimpleFont bool
         //ComplexOfNoiseText text noise count.
+        //   CaptchaComplexLower /  CaptchaComplexMedium  /  CaptchaComplexHigh
         ComplexOfNoiseText int
         //ComplexOfNoiseDot dot noise count.
         ComplexOfNoiseDot int
-        //IsUseSimpleFont is only use this (...fonts/RitaSmith.ttf)font.
-        IsUseSimpleFont bool
         //IsShowHollowLine is show hollow line.
         IsShowHollowLine bool
         //IsShowNoiseDot is show noise dot.
@@ -308,9 +345,27 @@ func main() {
         IsShowSlimeLine bool
         //IsShowSineLine is show sine line.
         IsShowSineLine bool
+
+        //CaptchaRunePairs make a list of rune for Captcha random selection.
+        // 随机字符串可选内容
+        ChineseCharacterSource string
+
+        // SequencedCharacters make a list of sequenced runes for Captcha random selection
+        //   Choose Mode base64captcha.CaptchaModeUseSequencedCharacters
+        //   随机字符串可选内容，词组内部保证顺序，使用模式CaptchaModeUseSequencedCharacters 使用
+        SequencedCharacters []string
+
+        //UseCJKFonts: ask if shell uses CJKFonts (now including 文泉驿微米黑)
+        // 是否使用CJK字体
+        UseCJKFonts bool
+
         // CaptchaLen Default number of digits in captcha solution.
         // 默认数字验证长度6.
         CaptchaLen int
+
+        //BgColor captcha image background color (optional)
+        //背景颜色
+        BgColor *color.RGBA
     }
     ```
 -  CaptchaInterface

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,12 @@ func demoCodeCaptchaCreate() {
 	var configC = base64Captcha.ConfigCharacter{
 		Height:             60,
 		Width:              240,
-		//const CaptchaModeNumber:数字,CaptchaModeAlphabet:字母,CaptchaModeArithmetic:算术,CaptchaModeNumberAlphabet:数字字母混合.
+		//const CaptchaModeNumber:数字
+		//      CaptchaModeAlphabet:字母
+		//      CaptchaModeArithmetic:算术
+		//      CaptchaModeNumberAlphabet:数字字母混合.
+		//      CaptchaModeChinese: 中文字符串
+		//      CaptchaModeUseSequencedCharacters:  在指定词组中随机（内部保持词组有序)
 		Mode:               base64Captcha.CaptchaModeNumber,
 		ComplexOfNoiseText: base64Captcha.CaptchaComplexLower,
 		ComplexOfNoiseDot:  base64Captcha.CaptchaComplexLower,
@@ -62,6 +67,10 @@ func demoCodeCaptchaCreate() {
 		IsShowNoiseText:    false,
 		IsShowSlimeLine:    false,
 		IsShowSineLine:     false,
+		// 随机中文字符串来源，在CaptchaModeChinese时有效。
+		ChineseCharacterSource： "",
+		// 随机词组，在CaptchaModeUseSequencedCharacters时有效
+		SequencedCharacters: []string {"中文","英文","其他"},
 		CaptchaLen:         6,
 	}
 	//创建声音验证码

--- a/_examples/static/index.html
+++ b/_examples/static/index.html
@@ -178,7 +178,7 @@
                             label-width="280px"
                             label-position="left">
                         <el-form-item label="ConfigCharacter.Mode">
-                            <el-slider v-model="form.ConfigCharacter.Mode" :min="0" :max="4"
+                            <el-slider v-model="form.ConfigCharacter.Mode" :min="0" :max="5"
                                        show-input
                                        show-stops
                                        :format-tooltip="formatTooltip"
@@ -189,12 +189,16 @@
                                        @change="generateCaptcha"></el-slider>
                         </el-form-item>
 
-
-
                         <el-form-item label="ConfigCharacter.ChineseCharacterSource" v-show="form.ConfigCharacter.Mode == 4">
                             <el-input v-model="form.ConfigCharacter.ChineseCharacterSource"
                                    type="textarea"
                                    @change="generateCaptcha"></el-input>
+                        </el-form-item>
+
+                        <el-form-item label="ConfigCharacter.SequencedCharacters" v-show="form.ConfigCharacter.Mode == 5">
+                            <el-input v-model="configCharacterSequencedCharacters"
+                            type="textarea"
+                            @change="generateCaptcha"></el-input>
                         </el-form-item>
 
                         <el-form-item label="ConfigCharacter.Width">
@@ -207,7 +211,11 @@
                                        show-input
                                        @change="generateCaptcha"></el-slider>
                         </el-form-item>
-
+                        <el-form-item label="ConfigCharacter.UseCJKFonts">
+                            <el-checkbox v-model="form.ConfigCharacter.UseCJKFonts" @change="generateCaptcha">
+                                UseCJKFonts
+                            </el-checkbox>
+                        </el-form-item>
                         <el-form-item label="ConfigCharacter.IsUseSimpleFont">
                             <el-checkbox v-model="form.ConfigCharacter.IsUseSimpleFont" @change="generateCaptcha">
                                 ...base64Captcha/fonts/RitaSmith.ttf
@@ -361,6 +369,7 @@
                         Height: 60,
                         Width: 240,
                         Mode: 2,
+                        SequencedCharacters: ["文件", "下载", "测试", "词组", "验证", "顺序"],
                         ComplexOfNoiseText: 0,
                         ComplexOfNoiseDot: 0,
                         IsUseSimpleFont: true,
@@ -384,21 +393,30 @@
                 loading: false
             }
         },
+        computed: {
+            configCharacterSequencedCharacters: {
+                get: function() {
+                    return this.form.ConfigCharacter.SequencedCharacters.join(',')
+                },
+                set: function(newValue) {
+                    this.form.ConfigCharacter.SequencedCharacters = newValue.split(',')
+                }
+            }
+        },
         methods: {
             formatTooltip: function (val) {
-                var items = ['CaptchaModeNumber', 'CaptchaModeAlphabet', 'CaptchaModeArithmetic', 'CaptchaModeNumberAlphabet'];
+                var items = ['CaptchaModeNumber', 'CaptchaModeAlphabet', 'CaptchaModeArithmetic', 
+                            'CaptchaModeNumberAlphabet', 'CaptchaModeChinese', 'CaptchaModeUseSequencedCharacters'];
                 return items[val];
             },
             handleClick: function (tab, event) {
                 this.generateCaptcha();
-            },
-
+            },            
             generateCaptcha: function () {
                 this.loading = true;
                 //generate uuid string so the serve can verify numbers in the png
                 //you can generate the captchaId in other way
                 var that = this;
-
 
                 // the api/getCaptcha endpoint only recieve captchaId paramenter
                 axios.post('/api/getCaptcha', that.form)

--- a/const.go
+++ b/const.go
@@ -64,6 +64,8 @@ const (
 	CaptchaModeNumberAlphabet
 	//CaptchaModeChinese made chinese captcha .
 	CaptchaModeChinese
+	//CaptchaModeUseSequencedCharacters uses Sequenced Characters.
+	CaptchaModeUseSequencedCharacters
 )
 
 //GoTestOutputDir run go test command where the png and wav file output

--- a/ng_img_char.go
+++ b/ng_img_char.go
@@ -41,7 +41,7 @@ type ConfigCharacter struct {
 	//    base64captcha.CaptchaModeArithmetic=2,
 	//    base64captcha.CaptchaModeNumberAlphabet=3,
 	//    base64captcha.CaptchaModeChinese=4,
-	//    base64captcha.CaptchaModeUseRunePairs=5
+	//    base64captcha.CaptchaModeUseSequencedCharacters=5
 	Mode int
 	//IsUseSimpleFont is use simply font(...base64Captcha/fonts/RitaSmith.ttf).
 	IsUseSimpleFont bool
@@ -64,6 +64,11 @@ type ConfigCharacter struct {
 	//CaptchaRunePairs make a list of rune for Captcha random selection.
 	// 随机字符串可选内容
 	ChineseCharacterSource string
+
+	// SequencedCharacters make a list of sequenced runes for Captcha random selection
+	//   Choose Mode base64captcha.CaptchaModeUseSequencedCharacters
+	//   随机字符串可选内容，词组内部保证顺序，使用模式CaptchaModeUseSequencedCharacters 使用
+	SequencedCharacters []string
 
 	//UseCJKFonts: ask if shell uses CJKFonts (now including 文泉驿微米黑)
 	// 是否使用CJK字体
@@ -373,7 +378,10 @@ func getTextContentByMode(config ConfigCharacter) (captchaContent string, verify
 		}
 		captchaContent = randText(config.CaptchaLen, config.ChineseCharacterSource)
 		verifyValue = captchaContent
-
+	// 随机字符（内部保证顺序）
+	case CaptchaModeUseSequencedCharacters:
+		captchaContent = randFromStringArray(config.CaptchaLen, config.SequencedCharacters)
+		verifyValue = captchaContent
 	default:
 		captchaContent = randText(config.CaptchaLen, TxtSimpleCharaters)
 		verifyValue = captchaContent
@@ -390,6 +398,9 @@ func checkConfigCharacter(config *ConfigCharacter) error {
 	}
 	if config.UseCJKFonts && len(cjkFontFamilys) == 0 {
 		return errors.New("no cjk Fonts found")
+	}
+	if config.Mode == CaptchaModeUseSequencedCharacters && len(config.SequencedCharacters) == 0 {
+		return errors.New("shell fill config.SequencedCharacters when config.Mode==CaptchaModeUseSequencedCharacters")
 	}
 	return nil
 

--- a/ng_img_char_test.go
+++ b/ng_img_char_test.go
@@ -11,7 +11,7 @@ func TestEngineCharCreate(t *testing.T) {
 	tc, _ := ioutil.TempDir("", "audio")
 	defer os.Remove(tc)
 	for i := 0; i < 16; i++ {
-		configC.Mode = 5
+		configC.Mode = i % 5
 		boooo := i%2 == 0
 		configC.IsUseSimpleFont = boooo
 		configC.IsShowSlimeLine = boooo
@@ -32,6 +32,31 @@ func TestEngineCharCreate(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestEngineCharUseSequencedCharacters(t *testing.T) {
+	tc, _ := ioutil.TempDir("", "UseSequencedCharacters")
+	defer os.Remove(tc)
+	configSequencedCharacters := configC
+	configSequencedCharacters.UseCJKFonts = true
+	configSequencedCharacters.Mode = CaptchaModeUseSequencedCharacters
+	configSequencedCharacters.SequencedCharacters = []string{
+		"文件", "下载", "测试", "词组", "验证", "顺序",
+	}
+	configSequencedCharacters.CaptchaLen = 9
+	im := EngineCharCreate(configSequencedCharacters)
+	rep := im.Content
+	for _, each := range configSequencedCharacters.SequencedCharacters {
+		rep = strings.Replace(rep, each, "", -1)
+	}
+	if len([]rune(rep)) != 1 {
+		t.Errorf("notgood: %v [rep=%v]", im.Content, rep)
+	}
+	fileName := strings.Trim(im.Content, "/+-+=?")
+	err := CaptchaWriteToFile(im, tc, fileName, "png")
+	if err != nil {
+		t.Error(err)
 	}
 }
 
@@ -59,6 +84,21 @@ func TestEngineCharCreatePanics(t *testing.T) {
 	t.Run("TestCaptchaLen_EQ_0", func(t *testing.T) {
 		configBad := configC
 		configBad.CaptchaLen = 0
+		defer func() {
+			if err := recover(); err != nil {
+				//good panic
+				return
+			}
+		}()
+		_ = EngineCharCreate(configBad)
+		t.Error("shell not be here")
+	})
+
+	t.Run("TestCaptchaModeUseSequencedCharacters", func(t *testing.T) {
+		configBad := configC
+		configBad.CaptchaLen = 9
+		configBad.Mode = CaptchaModeUseSequencedCharacters
+		configBad.SequencedCharacters = nil
 		defer func() {
 			if err := recover(); err != nil {
 				//good panic

--- a/random_math.go
+++ b/random_math.go
@@ -8,11 +8,11 @@ import (
 	"time"
 )
 
-//randFromRuneArray: create random text from sourceRuneArrays
-func randFromRuneArray(num int, sourceRuneArrays[][]rune) string {
+//randFromStringArray: create random text from sourceStringArray, ensure sequenced
+func randFromStringArray(num int, sourceStringArray []string) string {
 	target_runes := []rune{}
 	for len(target_runes) < num {
-		ftarget := randRuneArrayNext(sourceRuneArrays)
+		ftarget := []rune(randStringArrayNext(sourceStringArray))
 		// 切除超过需要字符的部分
 		icut := num - len(target_runes)
 		if icut > len(ftarget) {
@@ -24,12 +24,11 @@ func randFromRuneArray(num int, sourceRuneArrays[][]rune) string {
 }
 
 //randRuneArrayNext: select random one from input
-func randRuneArrayNext(input [][]rune) []rune {
+func randStringArrayNext(input []string) string {
 	r := randSeed()
 	i := r.Intn(len(input))
 	return input[i]
 }
-
 
 //randText create random text. 生成随机文本.
 func randText(num int, sourceChars string) string {


### PR DESCRIPTION
Fixes #42

1. ConfigCharacter API修改：
     新增Mode：CaptchaModeUseSequencedCharacters=5
	用于指定从顺序字符串中随机
     新增配置：SequencedCharacters
        用于指定顺序字符串，在CaptchaModeUseSequencedCharacters时可用

2. 新增限制：
     Mode为CaptchaModeUseSequencedCharacters时必须提供SequencedCharacters

3. 文档：
	_examples/static/index.html
	README.md
	README_zh.md

Signed-off-by: lilinzhe <slayercat.subscription@gmail.com>