### PR TITLE
fix DriverString Fonts not add

### DIFF
--- a/driver_string.go
+++ b/driver_string.go
@@ -54,7 +54,7 @@ func NewDriverString(height int, width int, noiseCount int, showLineOptions int,
 		tfs = fontsAll
 	}
 
-	return &DriverString{Height: height, Width: width, NoiseCount: noiseCount, ShowLineOptions: showLineOptions, Length: length, Source: source, BgColor: bgColor, fontsStorage: fontsStorage, fontsArray: tfs}
+	return &DriverString{Height: height, Width: width, NoiseCount: noiseCount, ShowLineOptions: showLineOptions, Length: length, Source: source, BgColor: bgColor, fontsStorage: fontsStorage, fontsArray: tfs, Fonts: fonts}
 }
 
 //ConvertFonts loads fonts by names


### PR DESCRIPTION
if not add fonts in DriverString, ConvertFonts() function use d.Fonts will empty lead to captcha use all Fonts.