### PR TITLE
Generate() add return 'answer'

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -24,30 +24,30 @@ type Captcha struct {
 	Store  Store
 }
 
-//NewCaptcha creates a captcha instance from driver and store
+// NewCaptcha creates a captcha instance from driver and store
 func NewCaptcha(driver Driver, store Store) *Captcha {
 	return &Captcha{Driver: driver, Store: store}
 }
 
-//Generate generates a random id, base64 image string or an error if any
-func (c *Captcha) Generate() (id, b64s string, err error) {
+// Generate generates a random id, base64 image string or an error if any
+func (c *Captcha) Generate() (id, b64s, answer string, err error) {
 	id, content, answer := c.Driver.GenerateIdQuestionAnswer()
 	item, err := c.Driver.DrawCaptcha(content)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	err = c.Store.Set(id, answer)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	b64s = item.EncodeB64string()
 	return
 }
 
-//Verify by a given id key and remove the captcha value in store,
-//return boolean value.
-//if you has multiple captcha instances which share a same store.
-//You may want to call `store.Verify` method instead.
+// Verify by a given id key and remove the captcha value in store,
+// return boolean value.
+// if you has multiple captcha instances which share a same store.
+// You may want to call `store.Verify` method instead.
 func (c *Captcha) Verify(id, answer string, clear bool) (match bool) {
 	vv := c.Store.Get(id, clear)
 	//fix issue for some redis key-value string value

--- a/driver_digit.go
+++ b/driver_digit.go
@@ -16,7 +16,7 @@ package base64Captcha
 
 import "math/rand"
 
-//DriverDigit config for captcha-engine-digit.
+// DriverDigit config for captcha-engine-digit.
 type DriverDigit struct {
 	// Height png height in pixel.
 	Height int
@@ -30,15 +30,15 @@ type DriverDigit struct {
 	DotCount int
 }
 
-//NewDriverDigit creates a driver of digit
+// NewDriverDigit creates a driver of digit
 func NewDriverDigit(height int, width int, length int, maxSkew float64, dotCount int) *DriverDigit {
 	return &DriverDigit{Height: height, Width: width, Length: length, MaxSkew: maxSkew, DotCount: dotCount}
 }
 
-//DefaultDriverDigit is a default driver of digit
+// DefaultDriverDigit is a default driver of digit
 var DefaultDriverDigit = NewDriverDigit(80, 240, 5, 0.7, 80)
 
-//GenerateIdQuestionAnswer creates captcha content and answer
+// GenerateIdQuestionAnswer creates captcha content and answer
 func (d *DriverDigit) GenerateIdQuestionAnswer() (id, q, a string) {
 	id = RandomId()
 	digits := randomDigits(d.Length)
@@ -46,7 +46,15 @@ func (d *DriverDigit) GenerateIdQuestionAnswer() (id, q, a string) {
 	return id, a, a
 }
 
-//DrawCaptcha creates digit captcha item
+// GenerateIdQuestionAnswer creates captcha content and answer
+func (d *DriverDigit) GenerateSpecificIdQuestionAnswer(mId string) (id, q, a string) {
+	id = mId
+	digits := randomDigits(d.Length)
+	a = parseDigitsToString(digits)
+	return id, a, a
+}
+
+// DrawCaptcha creates digit captcha item
 func (d *DriverDigit) DrawCaptcha(content string) (item Item, err error) {
 	// Initialize PRNG.
 	itemDigit := NewItemDigit(d.Width, d.Height, d.DotCount, d.MaxSkew)


### PR DESCRIPTION
Generate() func didn't return answer, better to return it
before -> return  (id, b64s string, err error) 
after -> return  (id, b64s, answer string, err error) 